### PR TITLE
luhn: avoid overspecification of addends

### DIFF
--- a/luhn/luhn_test.py
+++ b/luhn/luhn_test.py
@@ -1,3 +1,4 @@
+from collections import Counter
 import unittest
 
 from luhn import Luhn
@@ -5,10 +6,14 @@ from luhn import Luhn
 
 class LuhnTests(unittest.TestCase):
     def test_addends(self):
-        self.assertEqual([1, 4, 1, 4, 1], Luhn(12121).addends())
+        # uses a Counter to avoid specifying order of return value
+        self.assertEqual(Counter([1, 4, 1, 4, 1]),
+                         Counter(Luhn(12121).addends()))
 
     def test_addends_large(self):
-        self.assertEqual([7, 6, 6, 1], Luhn(8631).addends())
+        # uses a Counter to avoid specifying order of return value
+        self.assertEqual(Counter([7, 6, 6, 1]),
+                         Counter(Luhn(8631).addends()))
 
     def test_checksum1(self):
         self.assertEqual(2, Luhn(4913).checksum())


### PR DESCRIPTION
The existing tests:

```python
class LuhnTests(unittest.TestCase):
    def test_addends(self):
        self.assertEqual([1, 4, 1, 4, 1], Luhn(12121).addends())

    def test_addends_large(self):
        self.assertEqual([7, 6, 6, 1], Luhn(8631).addends())
```

required the output of addends() to be a list. This specifies not just the values, but also their order. 

The changes in this PR pass the previous expected list and the output of `addends()` to `collections.Counter`, then compares those objects. This enforces the contents of the return value without specifying order (or even type! Any iterable containing the right number of the right values should work.)

```python
class LuhnTests(unittest.TestCase):
    def test_addends(self):
        self.assertEqual(Counter([1, 4, 1, 4, 1]),
                         Counter(Luhn(12121).addends()))

    def test_addends_large(self):
        self.assertEqual(Counter([7, 6, 6, 1]),
                         Counter(Luhn(8631).addends()))
```

On the one hand, this avoids that overspecification. On the other hand, I think it may hurt readability for users who don't know about `Counter` yet.

Thoughts?
