### PR TITLE
added tests for a real 5th Monday of a month and for a nonexistant 5th Monday

### DIFF
--- a/meetup/meetup_test.py
+++ b/meetup/meetup_test.py
@@ -3,6 +3,10 @@ import unittest
 
 from meetup import meetup_day
 
+try:
+    from meetup import MeetupDayException
+except:
+    MeetupDayException = Exception
 
 class MeetupTest(unittest.TestCase):
     def test_monteenth_of_may_2013(self):
@@ -40,6 +44,14 @@ class MeetupTest(unittest.TestCase):
     def test_first_friday_of_december_2012(self):
         self.assertEqual(date(2012, 12, 7),
                          meetup_day(2012, 12, 'Friday', '1st'))
+
+    def test_fifth_monday_of_march_2015(self):
+        self.assertEqual(date(2015, 3, 30),
+                         meetup_day(2015, 3, 'Monday', '5th'))
+
+    def test_nonexistent_fifth_monday_of_february_2015(self):
+        self.assertRaises(MeetupDayException, meetup_day,
+                          2015, 2, 'Monday', '5th')
 
 if __name__ == '__main__':
     unittest.main()

--- a/meetup/meetup_test.py
+++ b/meetup/meetup_test.py
@@ -5,7 +5,7 @@ from meetup import meetup_day
 
 try:
     from meetup import MeetupDayException
-except:
+except ImportError:
     MeetupDayException = Exception
 
 class MeetupTest(unittest.TestCase):


### PR DESCRIPTION
I proposed this at the end of last year based on what I was seeing in others' solutions (see discussion here https://github.com/exercism/exercism.io/issues/2142) and @kytrinyx gave the go-ahead. 

Let me know what you think. Thanks!