### PR TITLE
Forcing Collision Detection in robot-name Exercise

### DIFF
--- a/robot-name/example.py
+++ b/robot-name/example.py
@@ -6,6 +6,7 @@ class Robot(object):
 
     def __init__(self):
         self._name = None
+        self._past_names = set()
 
     def prefix(self):
         return ''.join([
@@ -21,7 +22,13 @@ class Robot(object):
 
     def get_name(self):
         if not self._name:
-            self._name = self.prefix() + self.suffix()
+
+            # Collision detection
+            while True:
+                self._name = self.prefix() + self.suffix()
+                if self._name not in self._past_names:
+                    self._past_names.add(self._name)
+                    break
 
         return self._name
 

--- a/robot-name/robot_name_test.py
+++ b/robot-name/robot_name_test.py
@@ -1,6 +1,7 @@
 import unittest
 
 from robot import Robot
+import random
 
 
 class RobotTest(unittest.TestCase):
@@ -21,8 +22,20 @@ class RobotTest(unittest.TestCase):
         )
 
     def test_rest_name(self):
+        # Set a seed
+        seed = "Totally random."
+
+        # Initialize RNG using the seed
+        random.seed(seed)
+
+        # Call the generator
         robot = Robot()
         name = robot.name
+
+        # Reinitialize RNG using seed
+        random.seed(seed)
+
+        # Call the generator again
         robot.reset()
         name2 = robot.name
         self.assertNotEqual(name, name2)


### PR DESCRIPTION
The `test_rest_name` test seems to be written to catch whether the user is using collision detection, but since most people use RNG in their solutions, there's a minute probability of recognizing whether someone has implemented collision detection as currently written.

I rewrote the test to reset to a predefined seed before initialization and before resetting the name, which, if the same logic is used for generating the name in each case, will always result in identical names between the initialization and reset, which should force the need for collision detection.

I guess it'll still fail if there's a big enough difference between the initialization and reset logic (i.e. if they generate numbers first, then letters on the first run, and then do the reverse on the second), but it's a whole lot better than it was.

One last thing: the README for this exercise still treats collision detection as being optional, despite there being a test written to that effect. Should the README be modified as well?