### PR TITLE
Fix atbash-cipher test cases

### DIFF
--- a/atbash-cipher/atbash_cipher_test.py
+++ b/atbash-cipher/atbash_cipher_test.py
@@ -15,30 +15,30 @@ class AtbashCipherTest(unittest.TestCase):
         self.assertEqual("lnt", encode("OMG"))
 
     def test_encode_O_M_G(self):
-        self.assertEqual("lnt", encode("O M G"))
+        self.assertEqual("l n t", encode("O M G"))
 
     def test_encode_long_word(self):
-        self.assertEqual("nrmwy oldrm tob", encode("mindblowingly"))
+        self.assertEqual("nrmwyoldrmtob", encode("mindblowingly"))
 
     def test_encode_numbers(self):
-        self.assertEqual("gvhgr mt123 gvhgr mt",
+        self.assertEqual("gvhgrmt, 1 2 3, gvhgrmt.",
                          encode("Testing, 1 2 3, testing."))
 
     def test_encode_sentence(self):
-        self.assertEqual("gifgs rhurx grlm",
+        self.assertEqual("gifgs rh urxgrlm.",
                          encode("Truth is fiction."))
 
     def test_encode_all_things(self):
         plaintext = "The quick brown fox jumps over the lazy dog."
-        ciphertext = "gsvjf rxpyi ldmul cqfnk hlevi gsvoz abwlt"
+        ciphertext = "gsv jfrxp yildm ulc qfnkh levi gsv ozab wlt."
         self.assertEqual(ciphertext, encode(plaintext))
 
     def test_decode_word(self):
-        self.assertEqual("exercism", decode("vcvix rhn"))
+        self.assertEqual("exercism", decode("vcvixrhn"))
 
     def test_decode_sentence(self):
         self.assertEqual("anobstacleisoftenasteppingstone",
-                         decode("zmlyh gzxov rhlug vmzhg vkkrm thglm v"))
+                         decode("zmlyhgzxovrhlugvmzhgvkkrmthglmv"))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The current test cases are a bit strange. Some of them expect the cipher to
move spaces around, for example.

The tests now expect encode/decode to:

* Convert to lower case
* Encrypt alphabetical characters
* Preserve all other characters