### PR TITLE
Updated meetup tests to prevent creating a `datetime.date` with `mont…

### DIFF
--- a/meetup/meetup_test.py
+++ b/meetup/meetup_test.py
@@ -41,6 +41,10 @@ class MeetupTest(unittest.TestCase):
         self.assertEqual(date(2012, 2, 29),
                          meetup_day(2012, 2, 'Wednesday', 'last'))
 
+    def test_last_wednesday_of_december_2014(self):
+        self.assertEqual(date(2014, 12, 31),
+                         meetup_day(2014, 12, 'Wednesday', 'last'))
+
     def test_first_friday_of_december_2012(self):
         self.assertEqual(date(2012, 12, 7),
                          meetup_day(2012, 12, 'Friday', '1st'))


### PR DESCRIPTION
A common mistake I have seen is to calculate the last day of a month as:

    >>> date(year, month + 1, 1) - timedelta(days=1)

Which will raise a `ValueError` when `month` is `12` (December). This test
will prevent students from making this mistake again.