### PR TITLE
Formatted to be PEP8 compliant except line length

### DIFF
--- a/secret-handshake/example.py
+++ b/secret-handshake/example.py
@@ -1,4 +1,5 @@
-gestures = ['wink','double blink','close your eyes','jump']
+gestures = ['wink', 'double blink', 'close your eyes', 'jump']
+
 
 def handshake(s):
     s = list(sanitize(s))
@@ -12,6 +13,7 @@ def handshake(s):
         seq.reverse()
     return seq
 
+
 def code(seq):
     if not seq or set(seq)-set(gestures):
         return '0'
@@ -19,27 +21,29 @@ def code(seq):
     if not s:
         s = ['1'] + find_subseq(reversed(seq))
     return "".join(s)
-    
+
+
 def sanitize(s):
-    if not(isinstance(s, int) or isinstance(s,str)):
+    if not(isinstance(s, int) or isinstance(s, str)):
         raise TypeError('Unknown type')
-    if isinstance(s,int):
+    if isinstance(s, int):
         if s < 0:
             return ""
         s = bin(s)[2:]
-    elif set(s)-set(['0','1']):
+    elif set(s)-set(['0', '1']):
         return ""
     if len(s) > 5:
         raise ValueError('Binary string too long')
     return "0"*(len(gestures)-len(s)) + s
-    
+
+
 def find_subseq(seq):
     idx = 0
     s = []
     for g in seq:
         if g not in gestures[idx:]:
             return []
-        newidx = gestures.index(g,idx) + 1
+        newidx = gestures.index(g, idx) + 1
         s.extend(['0']*(newidx-idx-1)+['1'])
         idx = newidx
     s.reverse()

--- a/secret-handshake/handshake_test.py
+++ b/secret-handshake/handshake_test.py
@@ -1,4 +1,3 @@
-import os
 import unittest
 
 from handshake import handshake, code
@@ -6,13 +5,13 @@ from handshake import handshake, code
 
 class HandshakeTest(unittest.TestCase):
     def test_shake_int(self):
-        self.assertEqual(['wink','jump'], handshake(9))
+        self.assertEqual(['wink', 'jump'], handshake(9))
 
     def test_shake_bin1(self):
-        self.assertEqual(['close your eyes','double blink'], handshake('10110'))
+        self.assertEqual(['close your eyes', 'double blink'], handshake('10110'))
 
     def test_shake_bin2(self):
-        self.assertEqual(['wink','close your eyes'], handshake('101'))
+        self.assertEqual(['wink', 'close your eyes'], handshake('101'))
 
     def test_shake_negative_int(self):
         self.assertEqual([], handshake(-9))
@@ -21,16 +20,16 @@ class HandshakeTest(unittest.TestCase):
         self.assertEqual([], handshake('121'))
 
     def test_unknown_action(self):
-        self.assertEqual('0', code(['wink','sneeze']))
+        self.assertEqual('0', code(['wink', 'sneeze']))
 
     def test_code1(self):
-        self.assertEqual('1100', code(['close your eyes','jump']))
+        self.assertEqual('1100', code(['close your eyes', 'jump']))
 
     def test_code2(self):
-        self.assertEqual('11', code(['wink','double blink']))
+        self.assertEqual('11', code(['wink', 'double blink']))
 
     def test_code3(self):
-        self.assertEqual('11010', code(['jump','double blink']))
+        self.assertEqual('11010', code(['jump', 'double blink']))
 
     def test_composition1(self):
         self.assertEqual('11011', code(handshake(27)))
@@ -42,7 +41,7 @@ class HandshakeTest(unittest.TestCase):
         self.assertEqual('111', code(handshake('111')))
 
     def test_composition4(self):
-        inp = ['wink','double blink','jump']
+        inp = ['wink', 'double blink', 'jump']
         self.assertEqual(inp, handshake(code(inp)))
 
 


### PR DESCRIPTION
The exercise `secret-handshake` had some minor inconsistencies with PEP8 which I fixed except *E501 line too long (80 > 79 characters)*. I thought this might be a good small fix for me to make my first pull request ever and learn how this is done.

```
tmo$ flake8 secret-handshake/ --ignore=E501
secret-handshake/example.py:1:19: E231 missing whitespace after ','
secret-handshake/example.py:1:34: E231 missing whitespace after ','
secret-handshake/example.py:1:52: E231 missing whitespace after ','
secret-handshake/example.py:3:1: E302 expected 2 blank lines, found 1
secret-handshake/example.py:15:1: E302 expected 2 blank lines, found 1
secret-handshake/example.py:16:27: E226 missing whitespace around arithmetic operator
secret-handshake/example.py:22:1: W293 blank line contains whitespace
secret-handshake/example.py:23:1: E302 expected 2 blank lines, found 1
secret-handshake/example.py:24:46: E231 missing whitespace after ','
secret-handshake/example.py:26:20: E231 missing whitespace after ','
secret-handshake/example.py:30:16: E226 missing whitespace around arithmetic operator
secret-handshake/example.py:30:25: E231 missing whitespace after ','
secret-handshake/example.py:34:15: E226 missing whitespace around arithmetic operator
secret-handshake/example.py:34:30: E226 missing whitespace around arithmetic operator
secret-handshake/example.py:35:1: W293 blank line contains whitespace
secret-handshake/example.py:36:1: E302 expected 2 blank lines, found 1
secret-handshake/example.py:42:34: E231 missing whitespace after ','
secret-handshake/example.py:43:23: E226 missing whitespace around arithmetic operator
secret-handshake/example.py:43:31: E226 missing whitespace around arithmetic operator
secret-handshake/example.py:43:35: E226 missing whitespace around arithmetic operator
secret-handshake/example.py:43:38: E226 missing whitespace around arithmetic operator
secret-handshake/example.py:46:13: W292 no newline at end of file
secret-handshake/handshake_test.py:1:1: F401 'os' imported but unused
secret-handshake/handshake_test.py:9:33: E231 missing whitespace after ','
secret-handshake/handshake_test.py:12:44: E231 missing whitespace after ','
secret-handshake/handshake_test.py:15:33: E231 missing whitespace after ','
secret-handshake/handshake_test.py:24:43: E231 missing whitespace after ','
secret-handshake/handshake_test.py:27:57: E231 missing whitespace after ','
secret-handshake/handshake_test.py:30:44: E231 missing whitespace after ','
secret-handshake/handshake_test.py:33:47: E231 missing whitespace after ','
secret-handshake/handshake_test.py:45:22: E231 missing whitespace after ','
secret-handshake/handshake_test.py:45:37: E231 missing whitespace after ','
```
