### PR TITLE
Added support for Python 3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: python
 
 python:
   - 2.7
+  - 3.3
   - 3.4
   - 3.5
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,10 @@
 language: python
+
 python:
-  - "2.7"
-  - "3.3"
-  - "3.4"
+  - 2.7
+  - 3.4
+  - 3.5
+
 script:
   - ./test/check-exercises.py
   - ./bin/fetch-configlet

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Please see the [contributing guide](https://github.com/exercism/x-api/blob/maste
 We welcome both improvements to the existing exercises and new exercises.
 A pool of exercise ideas can be found in the [x-common repo](https://github.com/exercism/x-common).
 
-All exercises must be compatible with Python versions 2.7, 3.4 and 3.5.
+All exercises must be compatible with Python versions 2.7 and 3.3 upwards.
 Therefore please test your changes at least with Python2.7 and Python3.5.
 
 To test a single exercise, say crypto-square, run:

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ Please see the [contributing guide](https://github.com/exercism/x-api/blob/maste
 We welcome both improvements to the existing exercises and new exercises.
 A pool of exercise ideas can be found in the [x-common repo](https://github.com/exercism/x-common).
 
-All exercises must be compatible with Python versions 2.7, 3.3 and 3.4.
-Therefore please test your changes at least with Python2.7 and Python3.4.
+All exercises must be compatible with Python versions 2.7, 3.4 and 3.5.
+Therefore please test your changes at least with Python2.7 and Python3.5.
 
 To test a single exercise, say crypto-square, run:
 ```

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ python2.7 test/check_exercises.py crypto-square
 ```
 and
 ```
-python3.4 test/check_exercises.py crypto-square
+python3.5 test/check_exercises.py crypto-square
 ```
 
 To run the tests for all exercises type:


### PR DESCRIPTION
**Python 3.5.0** was released a month ago and all our tests run successfully with it. I added 3.5 to the travis-ci config and to the readme. Additionally I removed 3.3 which we could keep as the build doesn't take to long, but I don't think we really get something of it.

```
python3.5 test/check-exercises.py
# accumulate
......
----------------------------------------------------------------------
Ran 6 tests in 0.000s


[...]


# zebra_puzzle
.
----------------------------------------------------------------------
Ran 1 test in 0.000s

OK

SUCCESS!
```