### PR TITLE
ocr-numbers: PEP8 compliance updated

### DIFF
--- a/ocr-numbers/example.py
+++ b/ocr-numbers/example.py
@@ -3,7 +3,7 @@ COL = 3
 
 
 def split_ocr(ocr):
-    return [[ocr[i][COL*j:COL*(j+1)] for i in range(ROW)]
+    return [[ocr[i][COL * j:COL * (j + 1)] for i in range(ROW)]
             for j in range(len(ocr[0]) // COL)]
 
 ALL = ['    _  _     _  _  _  _  _  _ ',

--- a/ocr-numbers/example.py
+++ b/ocr-numbers/example.py
@@ -1,10 +1,10 @@
 ROW = 4
 COL = 3
 
+
 def split_ocr(ocr):
-    return [[ocr[i][COL*j:COL*(j+1)]
-	     for i in range(ROW)]
-	     for j in range(len(ocr[0])//COL)]
+    return [[ocr[i][COL*j:COL*(j+1)] for i in range(ROW)]
+            for j in range(len(ocr[0]) // COL)]
 
 ALL = ['    _  _     _  _  _  _  _  _ ',
        '  | _| _||_||_ |_   ||_||_|| |',
@@ -16,7 +16,7 @@ OCR_LIST = [OCR_LIST[-1]] + OCR_LIST[:9]
 
 
 def number(ocr):
-    if (len(ocr) != ROW or len(ocr[0])%COL or
+    if (len(ocr) != ROW or len(ocr[0]) % COL or
             any(len(r) != len(ocr[0]) for r in ocr)):
         raise ValueError('Wrong grid size.')
     numbers = split_ocr(ocr)

--- a/ocr-numbers/ocr_test.py
+++ b/ocr-numbers/ocr_test.py
@@ -6,7 +6,6 @@ and raise ValueErrors with meaningful error messages
 if necessary.
 """
 
-import os
 import unittest
 
 from ocr import grid, number
@@ -101,7 +100,7 @@ class OcrTest(unittest.TestCase):
                           "                              "], grid(digits))
 
     def test_invalid_grid(self):
-       self.assertRaises(ValueError, grid, '123a')
+        self.assertRaises(ValueError, grid, '123a')
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
The exercise `ocr-numbers` had some minor inconsistencies with PEP8 which I fixed.
```
tmo$ flake8 ocr-numbers/
ocr-numbers/example.py:4:1: E302 expected 2 blank lines, found 1
ocr-numbers/example.py:5:24: E226 missing whitespace around arithmetic operator
ocr-numbers/example.py:5:30: E226 missing whitespace around arithmetic operator
ocr-numbers/example.py:5:33: E226 missing whitespace around arithmetic operator
ocr-numbers/example.py:6:1: E101 indentation contains mixed spaces and tabs
ocr-numbers/example.py:6:1: W191 indentation contains tabs
ocr-numbers/example.py:6:7: E128 continuation line under-indented for visual indent
ocr-numbers/example.py:7:1: W191 indentation contains tabs
ocr-numbers/example.py:7:2: E101 indentation contains mixed spaces and tabs
ocr-numbers/example.py:7:7: E128 continuation line under-indented for visual indent
ocr-numbers/example.py:7:33: E226 missing whitespace around arithmetic operator
ocr-numbers/example.py:10:1: E101 indentation contains mixed spaces and tabs
ocr-numbers/example.py:19:39: E228 missing whitespace around modulo operator
ocr-numbers/ocr_test.py:9:1: F401 'os' imported but unused
ocr-numbers/ocr_test.py:104:8: E111 indentation is not a multiple of four
```