### PR TITLE
minesweeper: PEP8 compliance updated

### DIFF
--- a/minesweeper/example.py
+++ b/minesweeper/example.py
@@ -7,14 +7,15 @@ def board(inp):
         for i2 in range(rowlen):
             if b[i1][i2] != ' ':
                 continue
-            cnt = inp[i1-1][i2-1:i2+2].count('*') + \
-                    inp[i1][i2-1:i2+2].count('*') + \
-                    inp[i1+1][i2-1:i2+2].count('*')
+            cnt = inp[i1 - 1][i2 - 1:i2 + 2].count('*') + \
+                inp[i1][i2 - 1:i2 + 2].count('*') + \
+                inp[i1 + 1][i2 - 1:i2 + 2].count('*')
             if cnt == 0:
                 continue
             b[i1][i2] = str(cnt)
     return ["".join(r) for r in b]
-    
+
+
 def verify_board(inp):
     # Null board or a null row
     if not inp or not all(r for r in inp):
@@ -22,7 +23,7 @@ def verify_board(inp):
     # Rows with different lengths
     rowlen = len(inp[0])
     collen = len(inp)
-    if not all(len(r)==rowlen for r in inp):
+    if not all(len(r) == rowlen for r in inp):
         raise ValueError("Invalid board")
     # Unknown character in board
     cset = set()
@@ -31,6 +32,6 @@ def verify_board(inp):
     if cset - set('+- *|'):
         raise ValueError("Invalid board")
     # Borders not as expected
-    if any(inp[i1] != '+'+'-'*(rowlen-2)+'+' for i1 in [0,-1]) or \
-       any(inp[i1][i2] != '|' for i1 in range(1,collen-1) for i2 in [0,-1]):
+    if any(inp[i1] != '+' + '-' * (rowlen - 2) + '+' for i1 in [0, -1]) or \
+       any(inp[i1][i2] != '|' for i1 in range(1, collen - 1) for i2 in [0, -1]):
         raise ValueError("Invalid board")

--- a/minesweeper/minesweeper_test.py
+++ b/minesweeper/minesweeper_test.py
@@ -6,7 +6,6 @@ ValueError with a meaningfull error message if the
 input turns out to be malformed.
 """
 
-import os
 import unittest
 
 from minesweeper import board
@@ -34,7 +33,7 @@ class MinesweeperTest(unittest.TestCase):
 
     def test_board2(self):
         inp = ["+-----+",
-               "| * * |", 
+               "| * * |",
                "|     |",
                "|   * |",
                "|  * *|",
@@ -152,7 +151,7 @@ class MinesweeperTest(unittest.TestCase):
 
     def test_invalid_char(self):
         inp = ["+-----+",
-               "|X  * |", 
+               "|X  * |",
                "+-----+"]
         self.assertRaises(ValueError, board, inp)
 


### PR DESCRIPTION
The exercise `minesweeper ` had some minor inconsistencies with PEP8 which I fixed except E501 line too long.
```
tmo$ flake8 minesweeper/ --ignore=E501
minesweeper/example.py:10:25: E226 missing whitespace around arithmetic operator
minesweeper/example.py:10:31: E226 missing whitespace around arithmetic operator
minesweeper/example.py:10:36: E226 missing whitespace around arithmetic operator
minesweeper/example.py:11:21: E127 continuation line over-indented for visual indent
minesweeper/example.py:11:31: E226 missing whitespace around arithmetic operator
minesweeper/example.py:11:36: E226 missing whitespace around arithmetic operator
minesweeper/example.py:12:21: E127 continuation line over-indented for visual indent
minesweeper/example.py:12:27: E226 missing whitespace around arithmetic operator
minesweeper/example.py:12:33: E226 missing whitespace around arithmetic operator
minesweeper/example.py:12:38: E226 missing whitespace around arithmetic operator
minesweeper/example.py:17:1: W293 blank line contains whitespace
minesweeper/example.py:18:1: E302 expected 2 blank lines, found 1
minesweeper/example.py:25:22: E225 missing whitespace around operator
minesweeper/example.py:34:26: E226 missing whitespace around arithmetic operator
minesweeper/example.py:34:30: E226 missing whitespace around arithmetic operator
minesweeper/example.py:34:38: E226 missing whitespace around arithmetic operator
minesweeper/example.py:34:41: E226 missing whitespace around arithmetic operator
minesweeper/example.py:34:58: E231 missing whitespace after ','
minesweeper/example.py:35:48: E231 missing whitespace after ','
minesweeper/example.py:35:55: E226 missing whitespace around arithmetic operator
minesweeper/example.py:35:71: E231 missing whitespace after ','
minesweeper/example.py:36:42: W292 no newline at end of file
minesweeper/minesweeper_test.py:9:1: F401 'os' imported but unused
minesweeper/minesweeper_test.py:37:26: W291 trailing whitespace
minesweeper/minesweeper_test.py:155:26: W291 trailing whitespace
```