### PR TITLE
nth-prime: PEP8 compliance updated

### DIFF
--- a/nth-prime/nth_prime_test.py
+++ b/nth-prime/nth_prime_test.py
@@ -11,7 +11,8 @@ class NthPrimeTests(unittest.TestCase):
         self.assertEqual(13, nth_prime(6))
 
     def test_first_twenty_primes(self):
-        self.assertEqual([2,3,5,7,11,13,17,19,23,29,31,37,41,43,47,53,59,61,67,71],
+        self.assertEqual([2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31,
+                          37, 41, 43, 47, 53, 59, 61, 67, 71],
                          [nth_prime(n) for n in range(1, 21)])
 
     def test_prime_no_10000(self):


### PR DESCRIPTION
The exercise `nth-prime` had some minor inconsistencies with PEP8 which I fixed.

```
tmo$ flake8 nth-prime/
nth-prime/nth_prime_test.py:14:28: E231 missing whitespace after ','
nth-prime/nth_prime_test.py:14:30: E231 missing whitespace after ','
nth-prime/nth_prime_test.py:14:32: E231 missing whitespace after ','
nth-prime/nth_prime_test.py:14:34: E231 missing whitespace after ','
nth-prime/nth_prime_test.py:14:37: E231 missing whitespace after ','
nth-prime/nth_prime_test.py:14:40: E231 missing whitespace after ','
nth-prime/nth_prime_test.py:14:43: E231 missing whitespace after ','
nth-prime/nth_prime_test.py:14:46: E231 missing whitespace after ','
nth-prime/nth_prime_test.py:14:49: E231 missing whitespace after ','
nth-prime/nth_prime_test.py:14:52: E231 missing whitespace after ','
nth-prime/nth_prime_test.py:14:55: E231 missing whitespace after ','
nth-prime/nth_prime_test.py:14:58: E231 missing whitespace after ','
nth-prime/nth_prime_test.py:14:61: E231 missing whitespace after ','
nth-prime/nth_prime_test.py:14:64: E231 missing whitespace after ','
nth-prime/nth_prime_test.py:14:67: E231 missing whitespace after ','
nth-prime/nth_prime_test.py:14:70: E231 missing whitespace after ','
nth-prime/nth_prime_test.py:14:73: E231 missing whitespace after ','
nth-prime/nth_prime_test.py:14:76: E231 missing whitespace after ','
nth-prime/nth_prime_test.py:14:79: E231 missing whitespace after ','
nth-prime/nth_prime_test.py:14:80: E501 line too long (83 > 79 characters)
```