### PR TITLE
word-count: PEP8 compliance updated

### DIFF
--- a/word-count/word_count_test.py
+++ b/word-count/word_count_test.py
@@ -41,23 +41,25 @@ class WordCountTests(unittest.TestCase):
         )
 
     def test_multiple_spaces(self):
-      self.assertEqual(
-          {'wait': 1, 'for': 1, 'it': 1},
-          word_count('wait for       it')
-      )
+        self.assertEqual(
+            {'wait': 1, 'for': 1, 'it': 1},
+            word_count('wait for       it')
+        )
 
     def test_newlines(self):
         self.assertEqual(
             {'rah': 2, 'ah': 3, 'roma': 2, 'ma': 1, 'ga': 2, 'oh': 1, 'la': 2,
-            'want': 1, 'your': 1, 'bad': 1, 'romance': 1},
-            word_count('rah rah ah ah ah\nroma roma ma\nga ga oh la la\nwant your bad romance')
+             'want': 1, 'your': 1, 'bad': 1, 'romance': 1},
+            word_count('rah rah ah ah ah\nroma roma ma\n'
+                       'ga ga oh la la\nwant your bad romance')
         )
 
     def test_tabs(self):
         self.assertEqual(
             {'rah': 2, 'ah': 3, 'roma': 2, 'ma': 1, 'ga': 2, 'oh': 1, 'la': 2,
-            'want': 1, 'your': 1, 'bad': 1, 'romance': 1},
-            word_count('rah rah ah ah ah\troma roma ma\tga ga oh la la\twant your bad romance')
+             'want': 1, 'your': 1, 'bad': 1, 'romance': 1},
+            word_count('rah rah ah ah ah\troma roma ma\tga ga oh la la\t'
+                       'want your bad romance')
         )
 
 if __name__ == '__main__':


### PR DESCRIPTION
The exercise `word-count` had some minor inconsistencies with PEP8 which I fixed (#214).
```
tmo$ flake8 word-count/ --ignore=E501
word-count/word_count_test.py:44:7: E111 indentation is not a multiple of four
word-count/word_count_test.py:52:13: E128 continuation line under-indented for visual indent
word-count/word_count_test.py:59:13: E128 continuation line under-indented for visual indent
```