### PR TITLE
saddle-points: PEP8 compliance updated

### DIFF
--- a/saddle-points/example.py
+++ b/saddle-points/example.py
@@ -1,10 +1,11 @@
 def saddle_points(m):
     if not m:
         return set()
-    if any(len(r)!=len(m[0]) for r in m):
+    if any(len(r) != len(m[0]) for r in m):
         raise ValueError('irregular matrix')
     mmax = [max(r) for r in m]
     mmin = [min(c) for c in zip(*m)]
-    points = [(i,j) for i in range(len(m)) for j in range(len(m[0])) if mmax[i] == mmin[j]]
-    
+    points = [(i, j) for i in range(len(m))
+              for j in range(len(m[0])) if mmax[i] == mmin[j]]
+
     return set(points)


### PR DESCRIPTION
The exercise `saddle-points` had some minor inconsistencies with PEP8 which I fixed (#214).
```
tmo$ flake8 saddle-points/ --ignore=E501
saddle-points/example.py:4:18: E225 missing whitespace around operator
saddle-points/example.py:8:17: E231 missing whitespace after ','
saddle-points/example.py:9:1: W293 blank line contains whitespace
```