### PR TITLE
wordy: PEP8 compliance updated

### DIFF
--- a/wordy/wordy_test.py
+++ b/wordy/wordy_test.py
@@ -1,4 +1,3 @@
-import os
 import unittest
 
 from wordy import calculate


### PR DESCRIPTION
The exercise `wordy` had one minor inconsistency with PEP8 which I fixed (#214).
```
tmo$ flake8 wordy/ --ignore=E501
wordy/wordy_test.py:1:1: F401 'os' imported but unused
```