### PR TITLE
simple-cipher: PEP8 compliance updated

### DIFF
--- a/simple-cipher/simple_cipher_test.py
+++ b/simple-cipher/simple_cipher_test.py
@@ -37,7 +37,8 @@ class CipherTest(unittest.TestCase):
         self.assertEqual('yhqlylglylfl', c.encode('venividivici'))
 
     def test_cipher_encode4(self):
-        key = 'duxrceqyaimciuucnelkeoxjhdyduucpmrxmaivacmybmsdrzwqxvbxsygzsabdjmdjabeorttiwinfrpmpogvabiofqexnohrqu'
+        key = ('duxrceqyaimciuucnelkeoxjhdyduucpmrxmaivacmybmsdrzwqxvbxsy'
+               'gzsabdjmdjabeorttiwinfrpmpogvabiofqexnohrqu')
         c = Cipher(key)
         self.assertEqual('gccwkixcltycv', c.encode('diffiehellman'))
 
@@ -46,7 +47,8 @@ class CipherTest(unittest.TestCase):
         self.assertEqual('abcdabcd', c.encode('aaaaaaaa'))
 
     def test_cipher_compositiion1(self):
-        key = 'duxrceqyaimciuucnelkeoxjhdyduucpmrxmaivacmybmsdrzwqxvbxsygzsabdjmdjabeorttiwinfrpmpogvabiofqexnohrqu'
+        key = ('duxrceqyaimciuucnelkeoxjhdyduucpmrxmaivacmybmsdrzwqxvbxsy'
+               'gzsabdjmdjabeorttiwinfrpmpogvabiofqexnohrqu')
         plaintext = 'adaywithoutlaughterisadaywasted'
         c = Cipher(key)
         self.assertEqual(plaintext, c.decode(c.encode(plaintext)))
@@ -59,9 +61,9 @@ class CipherTest(unittest.TestCase):
     def test_cipher_random_key(self):
         c = Cipher()
         self.assertTrue(len(c.key) >= 100,
-            'A random key must be generated when no key is given!')
+                        'A random key must be generated when no key is given!')
         self.assertTrue(c.key.islower() and c.key.isalpha(),
-            'All items in the key must be chars and lowercase!')
+                        'All items in the key must be chars and lowercase!')
 
     def test_cipher_wrong_key(self):
         self.assertRaises(ValueError, Cipher, 'a1cde')


### PR DESCRIPTION
The exercise `simple-cipher` had some minor inconsistencies with PEP8 which I fixed (#214).
```
tmo$ flake8 simple-cipher/
simple-cipher/simple_cipher_test.py:40:80: E501 line too long (116 > 79 characters)
simple-cipher/simple_cipher_test.py:49:80: E501 line too long (116 > 79 characters)
simple-cipher/simple_cipher_test.py:62:13: E128 continuation line under-indented for visual indent
simple-cipher/simple_cipher_test.py:64:13: E128 continuation line under-indented for visual indent
```