### PR TITLE
bob: PEP8 compliance updated

### DIFF
--- a/bob/bob.py
+++ b/bob/bob.py
@@ -1,6 +1,8 @@
 #
 # Skeleton file for the Python "Bob" exercise.
 #
+
+
 def hey(what):
 
     return


### PR DESCRIPTION
The exercise `bob` had one minor inconsistency with PEP8 which I fixed (#214).
```
tmo$ flake8 bob/
bob/bob.py:4:1: E302 expected 2 blank lines, found 0
```