### PR TITLE
meetup: PEP8 compliance updated

### DIFF
--- a/meetup/meetup_test.py
+++ b/meetup/meetup_test.py
@@ -8,6 +8,7 @@ try:
 except ImportError:
     MeetupDayException = Exception
 
+
 class MeetupTest(unittest.TestCase):
     def test_monteenth_of_may_2013(self):
         self.assertEqual(date(2013, 5, 13),


### PR DESCRIPTION
The exercise `meetup` had one minor inconsistency with PEP8 which I fixed (#214).
```
tmo$ flake8 meetup/
meetup/meetup_test.py:11:1: E302 expected 2 blank lines, found 1
```