### PR TITLE
house: PEP8 compliance updated

### DIFF
--- a/house/example.py
+++ b/house/example.py
@@ -15,7 +15,7 @@ parts = [('lay in', 'the house that Jack built'),
 def verse(n):
     v = ['This is {}'.format(parts[n][1])]
     v.extend(['that {0} {1}'.format(parts[i][0], parts[i][1])
-              for i in range(n-1, -1, -1)])
+              for i in range(n - 1, -1, -1)])
     v[-1] += '.'
     return '\n'.join(v)
 


### PR DESCRIPTION
The exercise `house ` had one minor inconsistency with PEP8 which I fixed (#214).
```
tmo$ flake8 house/
house/example.py:18:31: E226 missing whitespace around arithmetic operator
```