### PR TITLE
phone-number: PEP8 compliance updated

### DIFF
--- a/phone-number/example.py
+++ b/phone-number/example.py
@@ -28,7 +28,7 @@ class Phone(object):
 
     def _normalize(self, number):
         valid = len(number) == 10 or \
-                len(number) == 11 and number.startswith('1')
+            len(number) == 11 and number.startswith('1')
 
         if valid:
             return number[-10:]


### PR DESCRIPTION
The exercise `phone-number` had one minor inconsistency with PEP8 which I fixed (#214).
```
tmo$ flake8 phone-number/
phone-number/example.py:31:17: E126 continuation line over-indented for hanging indent
```