### PR TITLE
strain: PEP8 compliance updated

### DIFF
--- a/strain/strain_test.py
+++ b/strain/strain_test.py
@@ -39,7 +39,7 @@ class StrainTest(unittest.TestCase):
     def test_keep_plus_discard(self):
         inp = ['1,2,3', 'one', 'almost!', 'love']
         out = ['one', 'love', '1,2,3', 'almost!']
-        self.assertEqual(out, keep(inp, str.isalpha)+discard(inp, str.isalpha))
+        self.assertEqual(out, keep(inp, str.isalpha) + discard(inp, str.isalpha))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The exercise `strain ` had one minor inconsistency with PEP8 which I fixed (#214).
```
tmo$ flake8 strain/ --ignore=E501
strain/strain_test.py:42:53: E226 missing whitespace around arithmetic operator
```