### PR TITLE
sublist: PEP8 compliance updated

### DIFF
--- a/sublist/sublist_test.py
+++ b/sublist/sublist_test.py
@@ -64,7 +64,7 @@ class SublistTest(unittest.TestCase):
         self.assertEqual(SUPERLIST, check_lists(l1, l2))
 
     def test_large_lists(self):
-        l1 = list(range(1000))*1000 + list(range(1000, 1100))
+        l1 = list(range(1000)) * 1000 + list(range(1000, 1100))
         l2 = list(range(900, 1050))
         self.assertEqual(SUPERLIST, check_lists(l1, l2))
 


### PR DESCRIPTION
The exercise `sublist ` had one minor inconsistency with PEP8 which I fixed (#214).
```
tmo$ flake8 sublist/ --ignore=E501
sublist/sublist_test.py:67:31: E226 missing whitespace around arithmetic operator
```