### PR TITLE
triangle: PEP8 compliance updated

### DIFF
--- a/triangle/example.py
+++ b/triangle/example.py
@@ -10,10 +10,7 @@ class Triangle(object):
             raise TriangleError
 
     def _invalid_lengths(self):
-        return any([
-            side <= 0 for side in self.sides
-        ])
-        return s
+        return any([side <= 0 for side in self.sides])
 
     def _violates_inequality(self):
         x, y, z = self.sides


### PR DESCRIPTION
The exercise `triangle ` had one inconsistency with PEP8 which I fixed (#214). It could also be called *unreachable code*.
```
tmo$ flake8 triangle/
triangle/example.py:16:16: F821 undefined name 's'
```