### PR TITLE
pascals-triangle: PEP8 compliance updated

### DIFF
--- a/pascals-triangle/example.py
+++ b/pascals-triangle/example.py
@@ -1,12 +1,14 @@
 def triangle(nth):
-    return [row(i) for i in range(nth+1)]
+    return [row(i) for i in range(nth + 1)]
+
 
 def is_triangle(t):
-    new_t = triangle(len(t)-1)
+    new_t = triangle(len(t) - 1)
     return t == new_t
+
 
 def row(nth):
     r = [1]
-    for i in range(1,nth+1):
-        r.append(int(r[-1]*(nth-i+1)/i))
+    for i in range(1, nth + 1):
+        r.append(int(r[-1] * (nth - i + 1) / i))
     return " ".join([str(i) for i in r])

--- a/pascals-triangle/pascals_triangle_test.py
+++ b/pascals-triangle/pascals_triangle_test.py
@@ -1,7 +1,7 @@
+import unittest
+
 from pascals_triangle import triangle, row, is_triangle
 
-import os
-import unittest
 
 class PascalsTriangleTest(unittest.TestCase):
     def test_triangle1(self):


### PR DESCRIPTION
The exercise `pascals-triangle ` had some inconsistency with PEP8 which I fixed (#214).
```
tmo$ flake8 pascals-triangle/
./pascals-triangle/example.py:2:38: E226 missing whitespace around arithmetic operator
./pascals-triangle/example.py:4:1: E302 expected 2 blank lines, found 1
./pascals-triangle/example.py:5:28: E226 missing whitespace around arithmetic operator
./pascals-triangle/example.py:8:1: E302 expected 2 blank lines, found 1
./pascals-triangle/example.py:10:21: E231 missing whitespace after ','
./pascals-triangle/example.py:10:25: E226 missing whitespace around arithmetic operator
./pascals-triangle/example.py:11:27: E226 missing whitespace around arithmetic operator
./pascals-triangle/example.py:11:32: E226 missing whitespace around arithmetic operator
./pascals-triangle/example.py:11:34: E226 missing whitespace around arithmetic operator
./pascals-triangle/example.py:11:37: E226 missing whitespace around arithmetic operator
```