### PR TITLE
nucleotide-count: PEP8 compliance updated

### DIFF
--- a/nucleotide-count/nucleotide_count_test.py
+++ b/nucleotide-count/nucleotide_count_test.py
@@ -26,13 +26,14 @@ class DNATest(unittest.TestCase):
 
     def test_counts_only_thymidine(self):
         self.assertEqual(1, count('GGGGGTAACCCGG', 'T'))
-        
+
     def test_validates_nucleotides(self):
         with self.assertRaises(ValueError):
             count("GACT", 'X')
 
     def test_counts_all_nucleotides(self):
-        dna = "AGCTTTTCATTCTGACTGCAACGGGCAATATGTCTCTGTGTGGATTAAAAAAAGAGTGTCTGATAGCAGC"
+        dna = ('AGCTTTTCATTCTGACTGCAACGGGCAATATGTCT'
+               'CTGTGTGGATTAAAAAAAGAGTGTCTGATAGCAGC')
         expected = {'A': 20, 'T': 21, 'G': 17, 'C': 12}
         self.assertEqual(expected, nucleotide_counts(dna))
 


### PR DESCRIPTION
The exercise `nucleotide-count` had one inconsistency with PEP8 which I fixed (#214).
```
tmo$ flake8 nucleotide-count/
./nucleotide-count/nucleotide_count_test.py:29:1: W293 blank line contains whitespace
```