### PR TITLE
accumulate: PEP8 compliance updated

### DIFF
--- a/accumulate/accumulate_test.py
+++ b/accumulate/accumulate_test.py
@@ -5,11 +5,11 @@ from accumulate import accumulate
 
 class AccumulateTest(unittest.TestCase):
     def test_empty_sequence(self):
-        self.assertEqual([], accumulate([], lambda x: x/2))
+        self.assertEqual([], accumulate([], lambda x: x / 2))
 
     def test_pow(self):
         self.assertEqual([1, 4, 9, 16, 25], accumulate([1, 2, 3, 4, 5],
-                         lambda x: x*x))
+                         lambda x: x * x))
 
     def test_divmod(self):
         inp = [10, 17, 23]
@@ -19,7 +19,7 @@ class AccumulateTest(unittest.TestCase):
     def test_composition(self):
         inp = [10, 17, 23]
         fn1 = lambda x: divmod(x, 7)
-        fn2 = lambda x: 7*x[0]+x[1]
+        fn2 = lambda x: 7 * x[0] + x[1]
         self.assertEqual(inp, accumulate(accumulate(inp, fn1), fn2))
 
     def test_capitalize(self):
@@ -30,7 +30,7 @@ class AccumulateTest(unittest.TestCase):
     def test_recursive(self):
         inp = list('abc')
         out = [['a1', 'a2', 'a3'], ['b1', 'b2', 'b3'], ['c1', 'c2', 'c3']]
-        fn = lambda x: accumulate(list('123'), lambda y: x+y)
+        fn = lambda x: accumulate(list('123'), lambda y: x + y)
         self.assertEqual(out, accumulate(inp, fn))
 
 

--- a/accumulate/example.py
+++ b/accumulate/example.py
@@ -1,7 +1,7 @@
 # [op(x) for x in seq] would be nice but trivial
 
 
-def accumulate(seq,op):
+def accumulate(seq, op):
     res = []
     for el in seq:
         res.append(op(el))


### PR DESCRIPTION
The exercise `accumulate` had some inconsistency with PEP8 which I fixed (#214).
```
tmo$ flake8 accumulate/ --ignore=E501
./accumulate/accumulate_test.py:8:56: E226 missing whitespace around arithmetic operator
./accumulate/accumulate_test.py:12:37: E226 missing whitespace around arithmetic operator
./accumulate/accumulate_test.py:22:26: E226 missing whitespace around arithmetic operator
./accumulate/accumulate_test.py:22:31: E226 missing whitespace around arithmetic operator
./accumulate/accumulate_test.py:33:59: E226 missing whitespace around arithmetic operator
./accumulate/example.py:4:19: E231 missing whitespace after ','
```