### PR TITLE
Add flake8 to travis-ci build process

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,14 @@ python:
   - 3.4
   - 3.5
 
+install:
+  - pip install flake8
+
+before_script:
+  # ignore:
+  # * E501 - line length limit
+  - flake8 . --ignore=E501
+
 script:
   - ./test/check-exercises.py
   - ./bin/fetch-configlet


### PR DESCRIPTION
#215, #216, #217, #218, #219, #220, #222, #223, #224, #225, #226, #227, #228, #229, #230, #231, #232, #233, #235, #236, #237, #238

After all the pull requests to fix the **PEP8** compliance I would like to never have to do this again. So I added `flake8` to the travis-ci build process. I think especially in a project that is not run by one person alone a strict linting is needed.

I deliberately excluded `E501 line too long`. There would be the option `--max-line-length` to raise the PEP8 limit of 79 characters but there are some test cases that have very long string data.