### PR TITLE
pig-latin: Implemented exercise from x-common

### DIFF
--- a/config.json
+++ b/config.json
@@ -28,6 +28,7 @@
     "luhn",
     "etl",
     "prime-factors",
+    "pig-latin",
     "simple-cipher",
     "scrabble-score",
     "crypto-square",

--- a/pig-latin/example.py
+++ b/pig-latin/example.py
@@ -1,0 +1,23 @@
+import re
+
+re_cons = re.compile('^([^aeiou]?qu|[^aeiou]+)([a-z]*)')
+re_vowel = re.compile('^([aeiou]|y[^aeiou]|xr)[a-z]*')
+
+
+def split_initial_consonant_sound(word):
+    return re_cons.match(word).groups()
+
+
+def starts_with_vowel_sound(word):
+    return re_vowel.match(word) is not None
+
+
+def translate(text):
+    words = []
+    for word in text.split():
+        if starts_with_vowel_sound(word):
+            words.append(word + 'ay')
+        else:
+            head, tail = split_initial_consonant_sound(word)
+            words.append(tail + head + 'ay')
+    return ' '.join(words)

--- a/pig-latin/pig_latin_test.py
+++ b/pig-latin/pig_latin_test.py
@@ -1,0 +1,53 @@
+import unittest
+
+from pig_latin import translate
+
+
+class PigLatinTests(unittest.TestCase):
+    def test_word_beginning_with_a(self):
+        self.assertEqual("appleay", translate("apple"))
+
+    def test_word_beginning_with_e(self):
+        self.assertEqual("earay", translate("ear"))
+
+    def test_word_beginning_with_p(self):
+        self.assertEqual("igpay", translate("pig"))
+
+    def test_word_beginning_with_k(self):
+        self.assertEqual("oalakay", translate("koala"))
+
+    def test_word_beginning_with_ch(self):
+        self.assertEqual("airchay", translate("chair"))
+
+    def test_word_beginning_with_qu(self):
+        self.assertEqual("eenquay", translate("queen"))
+
+    def test_word_beginning_with_squ(self):
+        self.assertEqual("aresquay", translate("square"))
+
+    def test_word_beginning_with_th(self):
+        self.assertEqual("erapythay", translate("therapy"))
+
+    def test_word_beginning_with_thr(self):
+        self.assertEqual("ushthray", translate("thrush"))
+
+    def test_word_beginning_with_sch(self):
+        self.assertEqual("oolschay", translate("school"))
+
+    def test_translates_phrase(self):
+        self.assertEqual("ickquay astfay unray", translate("quick fast run"))
+
+    def test_word_beginning_with_ye(self):
+        self.assertEqual("ellowyay", translate("yellow"))
+
+    def test_word_beginning_with_yt(self):
+        self.assertEqual("yttriaay", translate("yttria"))
+
+    def test_word_beginning_with_xe(self):
+        self.assertEqual("enonxay", translate("xenon"))
+
+    def test_word_beginning_with_xr(self):
+        self.assertEqual("xrayay", translate("xray"))
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
I implemented the **x-common/pig-latin** exercise ([README.md](https://github.com/exercism/x-common/blob/master/pig-latin.md). I placed it after `prime-factors` to alternate text and number exercises. Now after the commit I see it's followed by a *cipher* and *scrabble*, so we should search for a better spot in the track. Maybe between `nth-prime`and `saddle-points` might be a good spot.