### PR TITLE
nucleotide-count: now both count() and nucleotide_counts() reject invalid input.

### DIFF
--- a/nucleotide-count/example.py
+++ b/nucleotide-count/example.py
@@ -7,6 +7,8 @@ def count(strand, abbreviation):
 
 
 def nucleotide_counts(strand):
+    for x in strand:
+        _validate(x)
     return {
         abbr: strand.count(abbr)
         for abbr in 'ATGC'

--- a/nucleotide-count/nucleotide_count_test.py
+++ b/nucleotide-count/nucleotide_count_test.py
@@ -37,5 +37,9 @@ class DNATest(unittest.TestCase):
         expected = {'A': 20, 'T': 21, 'G': 17, 'C': 12}
         self.assertEqual(expected, nucleotide_counts(dna))
 
+    def test_validates_nucleotide_counts(self):
+        with self.assertRaises(ValueError):
+            nucleotide_counts('X')
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
added validation to nucleotide_counts(). now both count() and nucleotide_counts() reject invalid input. added a new test and corresponding implementation in the example.py