### PR TITLE
rna-transcription: Improve assertion message

### DIFF
--- a/rna-transcription/rna_transcription_test.py
+++ b/rna-transcription/rna_transcription_test.py
@@ -18,7 +18,7 @@ class DNATests(unittest.TestCase):
         self.assertEqual('U', to_rna('A'))
 
     def test_transcribes_all_occurences(self):
-        self.assertEqual('UGCACCAGAAUU', to_rna('ACGTGGTCTTAA'))
+        self.assertMultiLineEqual('UGCACCAGAAUU', to_rna('ACGTGGTCTTAA'))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
By using a more specific assertion method, we can improve the detail of the assertion error message. `assertMultiLineEqual` is used by default when Unicode strings are compared with assertEqual(). So this only effects Python 2.7 while Python 3 stays the same.

Now you can see which character is wrong, ...
```python
======================================================================
FAIL: test_transcribes_all_occurences (__main__.DNATests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/rna_transcription_test.py", line 21, in test_transcribes_all_occurences
    self.assertMultiLineEqual('UGCACCAGAXUU', to_rna('ACGTGGTCTTAA'))
AssertionError: 'UGCACCAGAXUU' != 'UGCACCAGAAUU'
- UGCACCAGAXUU
?          ^
+ UGCACCAGAAUU
?          ^

----------------------------------------------------------------------
```
... instead of a simple it doesn't match.
```python
======================================================================
FAIL: test_transcribes_all_occurences (__main__.DNATests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/rna_transcription_test.py", line 21, in test_transcribes_all_occurences
    self.assertEqual('UGCACCAGAXUU', to_rna('ACGTGGTCTTAA'))
AssertionError: 'UGCACCAGAXUU' != 'UGCACCAGAAUU'

----------------------------------------------------------------------
```