### PR TITLE
atbash-cipher: Improve assertion message

### DIFF
--- a/atbash-cipher/atbash_cipher_test.py
+++ b/atbash-cipher/atbash_cipher_test.py
@@ -6,39 +6,41 @@ from atbash_cipher import decode, encode
 class AtbashCipherTest(unittest.TestCase):
 
     def test_encode_no(self):
-        self.assertEqual("ml", encode("no"))
+        self.assertMultiLineEqual("ml", encode("no"))
 
     def test_encode_yes(self):
-        self.assertEqual("bvh", encode("yes"))
+        self.assertMultiLineEqual("bvh", encode("yes"))
 
     def test_encode_OMG(self):
-        self.assertEqual("lnt", encode("OMG"))
+        self.assertMultiLineEqual("lnt", encode("OMG"))
 
     def test_encode_O_M_G(self):
-        self.assertEqual("lnt", encode("O M G"))
+        self.assertMultiLineEqual("lnt", encode("O M G"))
 
     def test_encode_long_word(self):
-        self.assertEqual("nrmwy oldrm tob", encode("mindblowingly"))
+        self.assertMultiLineEqual("nrmwy oldrm tob", encode("mindblowingly"))
 
     def test_encode_numbers(self):
-        self.assertEqual("gvhgr mt123 gvhgr mt",
-                         encode("Testing, 1 2 3, testing."))
+        self.assertMultiLineEqual("gvhgr mt123 gvhgr mt",
+                                  encode("Testing, 1 2 3, testing."))
 
     def test_encode_sentence(self):
-        self.assertEqual("gifgs rhurx grlm",
-                         encode("Truth is fiction."))
+        self.assertMultiLineEqual("gifgs rhurx grlm",
+                                  encode("Truth is fiction."))
 
     def test_encode_all_things(self):
         plaintext = "The quick brown fox jumps over the lazy dog."
         ciphertext = "gsvjf rxpyi ldmul cqfnk hlevi gsvoz abwlt"
-        self.assertEqual(ciphertext, encode(plaintext))
+        self.assertMultiLineEqual(ciphertext, encode(plaintext))
 
     def test_decode_word(self):
-        self.assertEqual("exercism", decode("vcvix rhn"))
+        self.assertMultiLineEqual("exercism", decode("vcvix rhn"))
 
     def test_decode_sentence(self):
-        self.assertEqual("anobstacleisoftenasteppingstone",
-                         decode("zmlyh gzxov rhlug vmzhg vkkrm thglm v"))
+        self.assertMultiLineEqual(
+            "anobstacleisoftenasteppingstone",
+            decode("zmlyh gzxov rhlug vmzhg vkkrm thglm v")
+        )
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
By using a more specific assertion method, we can improve the detail of the assertion error message. `assertMultiLineEqual` is used by default when Unicode strings are compared with assertEqual(). So this only effects Python 2.7 while Python 3 stays the same.

Now you can see which character is missing or wrong, ...
```python
======================================================================
FAIL: test_encode_long_word (__main__.AtbashCipherTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/atbash_cipher_test.py", line 21, in test_encode_long_word
    self.assertMultiLineEqual("nrmwyoldrmtob", encode("mindblowingly"))
AssertionError: 'nrmwyoldrmtob' != 'nrmwy oldrm tob'
- nrmwyoldrmtob
+ nrmwy oldrm tob
?      +     +

----------------------------------------------------------------------
```
... instead of a simple it doesn't match.
```python
======================================================================
FAIL: test_encode_long_word (__main__.AtbashCipherTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/atbash_cipher_test.py", line 21, in test_encode_long_word
    self.assertEqual("nrmwyoldrmtob", encode("mindblowingly"))
AssertionError: 'nrmwyoldrmtob' != 'nrmwy oldrm tob'

----------------------------------------------------------------------
```