### PR TITLE
Update travis to docker container

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+sudo: false
+
 language: python
 
 python:


### PR DESCRIPTION
Migrate travis builds from legacy to container-based infrastructure. Details: [travis docs](https://docs.travis-ci.com/user/migrating-from-legacy/?utm_source=legacy-notice&utm_medium=banner&utm_campaign=legacy-upgrade)