### PR TITLE
nucleotide-count: refactor by removing duplication.

### DIFF
--- a/nucleotide-count/example.py
+++ b/nucleotide-count/example.py
@@ -1,4 +1,4 @@
-NUCLEOTIDES = 'ATCGU'
+NUCLEOTIDES = 'ATCG'
 
 
 def count(strand, abbreviation):
@@ -9,7 +9,7 @@ def count(strand, abbreviation):
 def nucleotide_counts(strand):
     return {
         abbr: strand.count(abbr)
-        for abbr in 'ATGC'
+        for abbr in NUCLEOTIDES
     }
 
 


### PR DESCRIPTION
refactored by removing duplication of symbol 'NUCLEOTIDES'.
also removed 'U' because we're not considering it a valid nucleotide
for the purpose of this exercise.