### PR TITLE
Normalize YAML in Travis CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,18 @@
+---
 sudo: false
-
 language: python
-
 python:
-  - 2.7
-  - 3.3
-  - 3.4
-  - 3.5
-
+- 2.7
+- 3.3
+- 3.4
+- 3.5
 install:
-  - pip install flake8
-
+- pip install flake8
 before_script:
-  # ignore:
-  # * E501 - line length limit
-  - flake8 . --ignore=E501
-
+# ignore:
+# * E501 - line length limit
+- flake8 . --ignore=E501
 script:
-  - ./test/check-exercises.py
-  - ./bin/fetch-configlet
-  - ./bin/configlet .
+- "./test/check-exercises.py"
+- "./bin/fetch-configlet"
+- "./bin/configlet ."


### PR DESCRIPTION
The YAML was not quite valid. Travis can read it
and wasn't complaining, but this ensures that the YAML
is clean.