### PR TITLE
accumulate: fix lambda usage (see #287)

### DIFF
--- a/accumulate/accumulate_test.py
+++ b/accumulate/accumulate_test.py
@@ -18,9 +18,8 @@ class AccumulateTest(unittest.TestCase):
 
     def test_composition(self):
         inp = [10, 17, 23]
-        fn1 = lambda x: divmod(x, 7)
-        fn2 = lambda x: 7 * x[0] + x[1]
-        self.assertEqual(inp, accumulate(accumulate(inp, fn1), fn2))
+        self.assertEqual(inp, accumulate(accumulate(inp, lambda x: divmod(x, 7)),
+                         lambda x: 7 * x[0] + x[1]))
 
     def test_capitalize(self):
         inp = ['hello', 'world']
@@ -30,8 +29,8 @@ class AccumulateTest(unittest.TestCase):
     def test_recursive(self):
         inp = list('abc')
         out = [['a1', 'a2', 'a3'], ['b1', 'b2', 'b3'], ['c1', 'c2', 'c3']]
-        fn = lambda x: accumulate(list('123'), lambda y: x + y)
-        self.assertEqual(out, accumulate(inp, fn))
+        self.assertEqual(out, accumulate(inp, lambda x: accumulate(list('123'),
+                         lambda y: x + y)))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Addresses an inconsistency with **PEP8** which brakes the travis-ci build.
```
./exercises/accumulate/accumulate_test.py:21:9: E731 do not assign a lambda expression, use a def
./exercises/accumulate/accumulate_test.py:22:9: E731 do not assign a lambda expression, use a def
./exercises/accumulate/accumulate_test.py:33:9: E731 do not assign a lambda expression, use a def
```