### PR TITLE
series: fix pep8 compliance (see #287)

### DIFF
--- a/series/example.py
+++ b/series/example.py
@@ -1,7 +1,6 @@
 def slices(series, length):
     numbers = [int(digit) for digit in series]
     if not 1 <= length <= len(numbers):
-        raise ValueError("Invalid slice length for this series: "
-                         + str(length))
+        raise ValueError("Invalid slice length for this series: " + str(length))
     return [numbers[i:i + length]
             for i in range(len(numbers) - length + 1)]


### PR DESCRIPTION
Addresses an inconsistency with **PEP8** which brakes the travis-ci build.
```
./exercises/series/example.py:5:26: W503 line break before binary operator
```