### PR TITLE
word-count: fix lambda usage (see #287)

### DIFF
--- a/word-count/example.py
+++ b/word-count/example.py
@@ -10,6 +10,7 @@ def decode_if_needed(string):
 
 
 def word_count(text):
-    replace_nonalpha = lambda c: c.lower() if c.isalnum() else ' '
+    def replace_nonalpha(char):
+        return char.lower() if char.isalnum() else ' '
     text = ''.join(replace_nonalpha(c) for c in decode_if_needed(text))
     return Counter(text.split())


### PR DESCRIPTION
Addresses an inconsistency with **PEP8** which brakes the travis-ci build.
```
./exercises/word-count/example.py:13:5: E731 do not assign a lambda expression, use a def
```