### PR TITLE
luhn: fix lambda usage (see #287)

### DIFF
--- a/luhn/example.py
+++ b/luhn/example.py
@@ -3,8 +3,9 @@ class Luhn(object):
         self.number = number
 
     def addends(self):
+        def luhn_transform(n):
+            return (2 * n - 9) if (n > 4) else (2 * n)
         old_digits = [int(d) for d in str(self.number)]
-        luhn_transform = lambda n: (2 * n - 9) if (n > 4) else (2 * n)
         return [(luhn_transform(n) if (i % 2 == 0) else n)
                 for i, n in enumerate(old_digits, start=len(old_digits) % 2)]
 


### PR DESCRIPTION
Addresses an inconsistency with **PEP8** which brakes the travis-ci build.
```
./exercises/luhn/example.py:7:9: E731 do not assign a lambda expression, use a def
```