### PR TITLE
strain: fix lambda usage (see #287)

### DIFF
--- a/strain/strain_test.py
+++ b/strain/strain_test.py
@@ -24,8 +24,7 @@ class StrainTest(unittest.TestCase):
     def test_discard_endswith(self):
         inp = ['dough', 'cash', 'plough', 'though', 'through', 'enough']
         out = ['cash']
-        fn = lambda x: str.endswith(x, 'ough')
-        self.assertEqual(out, discard(inp, fn))
+        self.assertEqual(out, discard(inp, lambda x: str.endswith(x, 'ough')))
 
     def test_keep_z(self):
         inp = ['zebra', 'arizona', 'apple', 'google', 'mozilla']


### PR DESCRIPTION
Addresses an inconsistency with **PEP8** which brakes the travis-ci build.
```
./exercises/strain/strain_test.py:27:9: E731 do not assign a lambda expression, use a def
```