### PR TITLE
Fix luhn's checksum wrong test values and its implementation.

### DIFF
--- a/exercises/luhn/example.py
+++ b/exercises/luhn/example.py
@@ -10,10 +10,10 @@ class Luhn(object):
                 for i, n in enumerate(old_digits, start=len(old_digits) % 2)]
 
     def checksum(self):
-        return sum(self.addends()) % 10
+        return sum(self.addends())
 
     def is_valid(self):
-        return self.checksum() == 0
+        return self.checksum() % 10 == 0
 
     @staticmethod
     def create(n):

--- a/exercises/luhn/luhn_test.py
+++ b/exercises/luhn/luhn_test.py
@@ -16,10 +16,10 @@ class LuhnTests(unittest.TestCase):
                          Counter(Luhn(8631).addends()))
 
     def test_checksum1(self):
-        self.assertEqual(2, Luhn(4913).checksum())
+        self.assertEqual(22, Luhn(4913).checksum())
 
     def test_ckecksum2(self):
-        self.assertEqual(1, Luhn(201773).checksum())
+        self.assertEqual(21, Luhn(201773).checksum())
 
     def test_invalid_number(self):
         self.assertFalse(Luhn(738).is_valid())


### PR DESCRIPTION
I finally managed to do it. Issue #284 pointed out the wrong checksum values in the test cases for the `luhn` exercise. I corrected them and corrected the implementation.

There's something I have to point out regarding the implementation of the exercise (`example.py`) though. I didn't really correct it, I just replaced the old one with my implementation _slightly_ modified. It works and all tests pass, but it would be nice to first give it a look and highlight potential problems.

As for the _slightly_ differences with my implementation all I changed is:
- added the `(object)` part to the first line `class Luhn(object)`. I don't really have a precise idea what it does, but it was there in the old implementation so I added it.
- removed the comments.
- cleaned up the unnecessary white spaces from empty lines (since last time I remember Flake8 complaining).

I hope I did everything the right way.