### PR TITLE
largest-series-product: Do not test slices

### DIFF
--- a/exercises/largest-series-product/largest_series_product_test.py
+++ b/exercises/largest-series-product/largest_series_product_test.py
@@ -1,26 +1,17 @@
 """Tests for the largest-series-product exercise
 
 Implementation note:
-In case of invalid inputs to the 'slices' or 'largest_product' functions
+In case of invalid inputs to the 'largest_product' function
 your program should raise a ValueError with a meaningful error message.
 
 Feel free to reuse your code for the series exercise!
 """
 import unittest
 
-from series import largest_product, slices
+from series import largest_product
 
 
 class SeriesTest(unittest.TestCase):
-    def test_slices_of_two(self):
-        self.assertEqual([[9, 7], [7, 8], [8, 6], [6, 7],
-                          [7, 5], [5, 6], [6, 4]],
-                         slices("97867564", 2))
-
-    def test_overly_long_slice(self):
-        with self.assertRaises(ValueError):
-            slices("012", 4)
-
     def test_largest_product_of_2(self):
         self.assertEqual(72, largest_product("0123456789", 2))
 


### PR DESCRIPTION
The slices functions is an internal implementation details and thus the
test case for the largest-series-product problem should not be concerned
with testing it.

Its presence may cause students to falsely think that their solution has
to use this function, instead of the alternative implementation of only
iterating through the digits once.

The series tests are already well-covered by the series exercise already
existing in this track.

If it is desired to give hints on how to approach this problem (which
was one advantage of having the slices test), then consider including a
hints file and/or directory in the largest-series-product directory.

This PR arises from discussion in
https://github.com/exercism/x-common/issues/192