### PR TITLE
pangram: Add extra invalid pangram test case

### DIFF
--- a/exercises/pangram/pangram_test.py
+++ b/exercises/pangram/pangram_test.py
@@ -14,6 +14,10 @@ class PangramTests(unittest.TestCase):
         self.assertTrue(
             is_pangram('the quick brown fox jumps over the lazy dog'))
 
+    def test_invalid_pangram(self):
+        self.assertFalse(
+            is_pangram('the quick brown fish jumps over the lazy dog'))
+
     def test_missing_x(self):
         self.assertFalse(is_pangram('a quick movement of the enemy will '
                                     'jeopardize five gunboats'))


### PR DESCRIPTION
I reviewed a solution that was passing the tests by coincidence - they were performing an alphabetic string comparison between sets of letters, and the only non empty False test case was passing because the string ('a quick movement...') is alphabetically less than 'abcdef...'. It seemed like another test case would help here!

(See http://exercism.io/submissions/c6790b9a65fe4c08b865e5eb621fe94d)