### PR TITLE
palindrome-products: test fix

### DIFF
--- a/exercises/palindrome-products/palindrome_products_test.py
+++ b/exercises/palindrome-products/palindrome_products_test.py
@@ -20,7 +20,7 @@ class PalindromesTests(unittest.TestCase):
     def test_largest_palindrome_from_single_digit_factors(self):
         value, factors = largest_palindrome(max_factor=9)
         self.assertEqual(9, value)
-        self.assertIn(set(factors), [{1, 9}, {3, 3}])
+        self.assertIn(set(factors), [{1, 9}, {3}])
 
     def test_largest_palindrome_from_double_digit_factors(self):
         value, factors = largest_palindrome(max_factor=99, min_factor=10)


### PR DESCRIPTION
Remove redundant '3' because {3, 3} is equivalent to {3}
