### PR TITLE
sublist: Adding test for unique return values

### DIFF
--- a/exercises/sublist/sublist_test.py
+++ b/exercises/sublist/sublist_test.py
@@ -4,6 +4,9 @@ from sublist import check_lists, SUBLIST, SUPERLIST, EQUAL, UNEQUAL
 
 
 class SublistTest(unittest.TestCase):
+    def test_unique_return_vals(self):
+        self.assertEqual(4, len(set([SUBLIST, SUPERLIST, EQUAL, UNEQUAL])))
+
     def test_empty_lists(self):
         self.assertEqual(EQUAL, check_lists([], []))
 


### PR DESCRIPTION
Adds a simple test for checking if the user-defined return values (SUBLIST, SUPERLIST, EQUAL, and UNEQUAL) have different values.

Simple fix to get around the problem raised in Issue #342 