### PR TITLE
Word-count test name fix

### DIFF
--- a/exercises/word-count/word_count_test.py
+++ b/exercises/word-count/word_count_test.py
@@ -32,7 +32,7 @@ class WordCountTests(unittest.TestCase):
             word_count('one fish two fish red fish blue fish')
         )
 
-    def test_preserves_punctuation(self):
+    def test_ignores_punctuation(self):
         self.assertEqual(
             {'car': 1, 'carpet': 1, 'as': 1, 'java': 1, 'javascript': 1},
             word_count('car : carpet as java : javascript!!&@$%^&')


### PR DESCRIPTION
This test says "preserves_punction" when it's really testing that punctuation is being ignored (i.e. not included in the list of words being counted).