### PR TITLE
add topics to clock exercise in config.json

### DIFF
--- a/config.json
+++ b/config.json
@@ -80,8 +80,13 @@
     },
     {
       "slug": "clock",
-      "difficulty": 1,
+      "difficulty": 2,
       "topics": [
+          "classes",
+          "time",
+          "mathematics",
+          "logic",
+          "text formatting"
       ]
     },
     {


### PR DESCRIPTION
addresses #353 

As I mentioned in #357 I was tempted to bump the difficulty up here as well, because I found there was a fair bit of research into classes involved, (`__repr__`, `__eq__`) even though it may not necessarily be difficult to implement. In the end I felt that having to research a problem doesn't make it more difficult. Again it's that fine line of a problem appearing difficult when we don't know the answer, and then losing some of that appearance of difficulty once solved.