### PR TITLE
binary-search: Add to "exercises" key in config

### DIFF
--- a/config.json
+++ b/config.json
@@ -437,6 +437,12 @@
       "difficulty": 1,
       "topics": [
       ]
+    },
+    {
+      "slug": "binary-search",
+      "difficulty": 1,
+      "topics": [
+      ]
     }
   ],
   "deprecated": [


### PR DESCRIPTION
Adds the exercise to the "exercises" key in the config.json (see #360).