### PR TITLE
Add flatten array exercise

### DIFF
--- a/config.json
+++ b/config.json
@@ -28,6 +28,7 @@
     "largest-series-product",
     "kindergarten-garden",
     "grade-school",
+    "flatten-array",
     "roman-numerals",
     "space-age",
     "grains",
@@ -218,6 +219,12 @@
     },
     {
       "slug": "grade-school",
+      "difficulty": 1,
+      "topics": [
+      ]
+    },
+    {
+      "slug": "flatten-array",
       "difficulty": 1,
       "topics": [
       ]

--- a/exercises/flatten-array/example.py
+++ b/exercises/flatten-array/example.py
@@ -1,11 +1,17 @@
-from collections.abc import Iterable
+def is_iterable(thing):
+    try:
+        iter(thing)
+    except TypeError:
+        return False
+    else:
+        return True
 
 
 def flatten(iterable):
     """Flatten a list of lists."""
     flattened = []
     for item in iterable:
-        if isinstance(item, Iterable) and not isinstance(item, (str, bytes)):
+        if is_iterable(item) and not isinstance(item, (str, bytes)):
             flattened += flatten(item)
         elif item is not None:
             flattened.append(item)

--- a/exercises/flatten-array/example.py
+++ b/exercises/flatten-array/example.py
@@ -1,0 +1,12 @@
+from collections.abc import Iterable
+
+
+def flatten(iterable):
+    """Flatten a list of lists."""
+    flattened = []
+    for item in iterable:
+        if isinstance(item, Iterable) and not isinstance(item, (str, bytes)):
+            flattened += flatten(item)
+        elif item is not None:
+            flattened.append(item)
+    return flattened

--- a/exercises/flatten-array/flatten_array_test.py
+++ b/exercises/flatten-array/flatten_array_test.py
@@ -1,0 +1,40 @@
+import unittest
+
+from flatten_array import flatten
+
+
+class FlattenArrayTests(unittest.TestCase):
+
+    def test_no_nesting(self):
+        self.assertEqual(flatten([0, 1, 2]), [0, 1, 2])
+
+    def test_one_level_nesting(self):
+        self.assertEqual(flatten([0, [1], 2]), [0, 1, 2])
+
+    def test_two_level_nesting(self):
+        self.assertEqual(flatten([0, [1, [2, 3]], [4]]), [0, 1, 2, 3, 4])
+
+    def test_empty_nested_lists(self):
+        self.assertEqual(flatten([[()]]), [])
+
+    def test_with_none_values(self):
+        inputs = [0, 2, [[2, 3], 8, [[100]], None, [[None]]], -2]
+        expected = [0, 2, 2, 3, 8, 100, -2]
+        self.assertEqual(flatten(inputs), expected)
+
+    def test_six_level_nesting(self):
+        inputs = [1, [2, [[3]], [4, [[5]]], 6, 7], 8]
+        expected = [1, 2, 3, 4, 5, 6, 7, 8]
+        self.assertEqual(flatten(inputs), expected)
+
+    def test_all_values_are_none(self):
+        inputs = [None, [[[None]]], None, None, [[None, None], None], None]
+        expected = []
+        self.assertEqual(flatten(inputs), expected)
+
+    def test_strings(self):
+        self.assertEqual(flatten(['0', ['1', '2']]), ['0', '1', '2'])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
I'm not entirely sure whether I updated the `config.json` file appropriately.

One issue I have with this exercise currently: "array" is not a word we use in Python.  Could we rename this to "flatten-list" or just "flatten" (which I think would be best)?  Would that be problematic because the exercise is called something different for the other languages?