### PR TITLE
rna_transcription: Add invalid input support

### DIFF
--- a/exercises/rna-transcription/example.py
+++ b/exercises/rna-transcription/example.py
@@ -6,8 +6,13 @@ else:
     maketrans = str.maketrans
 
 
-DNA_TO_RNA = maketrans('AGCT', 'UCGA')
+DNA_CHARS = 'AGCT'
+DNA_TO_RNA = maketrans(DNA_CHARS, 'UCGA')
 
 
 def to_rna(dna_strand):
+    valid_chars = set(DNA_CHARS)
+    if any(char not in valid_chars for char in dna_strand):
+        return ''
+
     return dna_strand.translate(DNA_TO_RNA)

--- a/exercises/rna-transcription/rna_transcription_test.py
+++ b/exercises/rna-transcription/rna_transcription_test.py
@@ -20,6 +20,15 @@ class DNATests(unittest.TestCase):
     def test_transcribes_all_occurences(self):
         self.assertMultiLineEqual('UGCACCAGAAUU', to_rna('ACGTGGTCTTAA'))
 
+    def test_correctly_handles_single_invalid_input(self):
+        self.assertEqual('', to_rna('U'))
+
+    def test_correctly_handles_completely_invalid_input(self):
+        self.assertMultiLineEqual('', to_rna('XXX'))
+
+    def test_correctly_handles_partially_invalid_input(self):
+        self.assertMultiLineEqual('', to_rna('ACGTXXXCTTAA'))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Now reflects the canonical test data defined in x-common (see [canonical-data.json](https://github.com/exercism/x-common/blob/master/exercises/rna-transcription/canonical-data.json)).

To work with the 3 new test cases I had to add a way to detect not valid input to the example implementation. While there are many ways to do this (*regex* being one of them) I thought the `if any(char not in valid_chars ...` construct is maybe the most self explanatory.

**Note:** *It would be great to get this merged before this weekend (November 26th) as there is a [code hangout](https://codebuddies.org/hangout/8An374DNxwZ38PJeF) planned.*