### PR TITLE
hamming: Add invalid input support

### DIFF
--- a/exercises/hamming/example.py
+++ b/exercises/hamming/example.py
@@ -1,2 +1,5 @@
 def distance(s1, s2):
+    if len(s1) != len(s2):
+        raise ValueError("Sequences not of equal length.")
+
     return sum(a != b for a, b in zip(s1, s2))

--- a/exercises/hamming/hamming_test.py
+++ b/exercises/hamming/hamming_test.py
@@ -5,26 +5,52 @@ import hamming
 
 class HammingTest(unittest.TestCase):
 
-    def test_no_difference_between_identical_strands(self):
-        self.assertEqual(0, hamming.distance('A', 'A'))
+    def test_identical_strands(self):
+        self.assertEqual(0, hamming.distance("A", "A"))
 
-    def test_complete_hamming_distance_of_for_single_nucleotide_strand(self):
-        self.assertEqual(1, hamming.distance('A', 'G'))
+    def test_long_identical_strands(self):
+        self.assertEqual(0, hamming.distance("GGACTGA", "GGACTGA"))
 
-    def test_complete_hamming_distance_of_for_small_strand(self):
-        self.assertEqual(2, hamming.distance('AG', 'CT'))
+    def test_complete_distance_in_single_nucleotide_strands(self):
+        self.assertEqual(1, hamming.distance("A", "G"))
 
-    def test_small_hamming_distance(self):
-        self.assertEqual(1, hamming.distance('AT', 'CT'))
+    def test_complete_distance_in_small_strands(self):
+        self.assertEqual(2, hamming.distance("AG", "CT"))
 
-    def test_small_hamming_distance_in_longer_strand(self):
-        self.assertEqual(1, hamming.distance('GGACG', 'GGTCG'))
+    def test_small_distance_in_small_strands(self):
+        self.assertEqual(1, hamming.distance("AT", "CT"))
 
-    def test_large_hamming_distance(self):
-        self.assertEqual(4, hamming.distance('GATACA', 'GCATAA'))
+    def test_small_distance(self):
+        self.assertEqual(1, hamming.distance("GGACG", "GGTCG"))
 
-    def test_hamming_distance_in_very_long_strand(self):
-        self.assertEqual(9, hamming.distance('GGACGGATTCTG', 'AGGACGGATTCT'))
+    def test_small_distance_in_long_strands(self):
+        self.assertEqual(2, hamming.distance("ACCAGGG", "ACTATGG"))
+
+    def test_non_unique_character_in_first_strand(self):
+        self.assertEqual(1, hamming.distance("AGA", "AGG"))
+
+    def test_non_unique_character_in_second_strand(self):
+        self.assertEqual(1, hamming.distance("AGG", "AGA"))
+
+    def test_same_nucleotides_in_different_positions(self):
+        self.assertEqual(2, hamming.distance("TAG", "GAT"))
+
+    def test_large_distance(self):
+        self.assertEqual(4, hamming.distance("GATACA", "GCATAA"))
+
+    def test_large_distance_in_off_by_one_strand(self):
+        self.assertEqual(9, hamming.distance("GGACGGATTCTG", "AGGACGGATTCT"))
+
+    def test_empty_strands(self):
+        self.assertEqual(0, hamming.distance("", ""))
+
+    def test_disallow_first_strand_longer(self):
+        with self.assertRaises(ValueError):
+            hamming.distance("AATG", "AAA")
+
+    def test_disallow_second_strand_longer(self):
+        with self.assertRaises(ValueError):
+            hamming.distance("ATA", "AGTG")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Now reflects the canonical test data defined in x-common (see [canonical-data.json](https://github.com/exercism/x-common/blob/master/exercises/hamming/canonical-data.json)).

The existing implementation worked with all new test cases except the last two, so I had to add a simple input validation.

**Note:** *It would be great to get this merged before this weekend (November 26th) as there is a [code hangout](https://codebuddies.org/hangout/8An374DNxwZ38PJeF) planned.*