### PR TITLE
atbash_cipher_test: Add 2 tests; leap: change all tests

### DIFF
--- a/exercises/atbash-cipher/atbash_cipher_test.py
+++ b/exercises/atbash-cipher/atbash_cipher_test.py
@@ -42,6 +42,18 @@ class AtbashCipherTest(unittest.TestCase):
             decode("zmlyh gzxov rhlug vmzhg vkkrm thglm v")
         )
 
+    def test_decode_numbers(self):
+        self.assertMultiLineEqual(
+            "testing123testing",
+            decode("gvhgr mt123 gvhgr mt")
+        )
+
+    def test_encode_decode(self):
+        self.assertMultiLineEqual(
+            "testing123testing",
+            decode(encode("Testing, 1 2 3, testing."))
+        )
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/exercises/leap/leap_test.py
+++ b/exercises/leap/leap_test.py
@@ -5,19 +5,19 @@ from leap import is_leap_year
 
 class YearTest(unittest.TestCase):
     def test_leap_year(self):
-        self.assertIs(is_leap_year(1996), True)
+        self.assertTrue(is_leap_year(1996))
 
     def test_non_leap_year(self):
-        self.assertIs(is_leap_year(1997), False)
+        self.assertFalse(is_leap_year(1997))
 
     def test_non_leap_even_year(self):
-        self.assertIs(is_leap_year(1998), False)
+        self.assertFalse(is_leap_year(1998))
 
     def test_century(self):
-        self.assertIs(is_leap_year(1900), False)
+        self.assertFalse(is_leap_year(1900))
 
     def test_exceptional_century(self):
-        self.assertIs(is_leap_year(2400), True)
+        self.assertTrue(is_leap_year(2400))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Add `test_decode_number` as there is a test that encode number. Check this _iteration_[1] for a solution that pass the tests without checking for alphanumeric in decode.

Add `test_encode_decode`. Having done this in the first place, would had highlighted the need of checking for alphanumeric in decoding.

[1] http://exercism.io/submissions/c7c9448e6a674dd6a11ea35dc32e29a4