### PR TITLE
list-ops: fix reversed tuple test

### DIFF
--- a/exercises/list-ops/example.py
+++ b/exercises/list-ops/example.py
@@ -1,13 +1,13 @@
 def map_clone(function, xs):
-    return (function(elem) for elem in xs)
+    return [function(elem) for elem in xs]
 
 
 def length(xs):
-    return sum(1 for x in xs)
+    return sum(1 for _ in xs)
 
 
 def filter_clone(function, xs):
-    return (x for x in xs if function(x))
+    return [x for x in xs if function(x)]
 
 
 def reverse(xs):
@@ -23,14 +23,14 @@ def append(xs, y):
 
 
 def foldl(function, xs, acc):
-    if(len(xs) == 0):
+    if len(xs) == 0:
         return acc
     else:
         return foldl(function, xs[1:], function(acc, xs[0]))
 
 
 def foldr(function, xs, acc):
-    if(len(xs) == 0):
+    if len(xs) == 0:
         return acc
     else:
         return function(xs[0], foldr(function, xs[1:], acc))
@@ -39,7 +39,7 @@ def foldr(function, xs, acc):
 def flat(xs):
     out = []
     for item in xs:
-        if isinstance(item, (list, tuple)):
+        if isinstance(item, list):
             out.extend(flat(item))
         else:
             out.append(item)

--- a/exercises/list-ops/list_ops_test.py
+++ b/exercises/list-ops/list_ops_test.py
@@ -9,34 +9,28 @@ class ListOpsTest(unittest.TestCase):
     # tests for map
     def test_map_square(self):
         self.assertEqual(
-            (1, 4, 9, 16, 25, 36, 49, 64, 81, 100),
-            tuple(list_ops.map_clone(
-                lambda x: x**2, (1, 2, 3, 4, 5, 6, 7, 8, 9, 10))
-            )
-        )
+            [1, 4, 9, 16, 25, 36, 49, 64, 81, 100],
+            list_ops.map_clone(
+                lambda x: x**2, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]))
 
     def test_map_cube(self):
         self.assertEqual(
-            (-1, 8, -27, 64, -125, 216, -343, 512, -729, 1000),
-            tuple(list_ops.map_clone(
-                lambda x: x**3, (-1, 2, -3, 4, -5, 6, -7, 8, -9, 10))
-            )
-        )
+            [-1, 8, -27, 64, -125, 216, -343, 512, -729, 1000],
+            list_ops.map_clone(
+                lambda x: x**3, [-1, 2, -3, 4, -5, 6, -7, 8, -9, 10]))
 
     def test_map_absolute(self):
         self.assertEqual(
-            (1, 2, 3, 4, 5, 6, 7, 8, 9, 10),
-            tuple(list_ops.map_clone(
-                lambda x: abs(x), (-1, 2, -3, 4, -5, 6, -7, 8, -9, 10))
-            )
-        )
+            [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+            list_ops.map_clone(
+                lambda x: abs(x), [-1, 2, -3, 4, -5, 6, -7, 8, -9, 10]))
 
     def test_map_empty(self):
-        self.assertEqual([], list(list_ops.map_clone(operator.index, [])))
+        self.assertEqual([], list_ops.map_clone(operator.index, []))
 
     # tests for length
     def test_pos_leng(self):
-        self.assertEqual(10, list_ops.length((-1, 2, -3, 4, -5, 6, -7, 8, -9, 10)))
+        self.assertEqual(10, list_ops.length([-1, 2, -3, 4, -5, 6, -7, 8, -9, 10]))
 
     def test_empty_len(self):
         self.assertEqual(0, list_ops.length([]))
@@ -44,15 +38,13 @@ class ListOpsTest(unittest.TestCase):
     # tests for filter
     def test_filter_odd(self):
         self.assertEqual(
-            (1, 3, 5),
-            tuple(list_ops.filter_clone(lambda x: x % 2 != 0, [1, 2, 3, 4, 5, 6]))
-        )
+            [1, 3, 5],
+            list_ops.filter_clone(lambda x: x % 2 != 0, [1, 2, 3, 4, 5, 6]))
 
     def test_filter_even(self):
         self.assertEqual(
-            (2, 4, 6),
-            tuple(list_ops.filter_clone(lambda x: x % 2 == 0, [1, 2, 3, 4, 5, 6]))
-        )
+            [2, 4, 6],
+            list_ops.filter_clone(lambda x: x % 2 == 0, [1, 2, 3, 4, 5, 6]))
 
     # tests for reverse
     def test_reverse_small(self):
@@ -60,19 +52,17 @@ class ListOpsTest(unittest.TestCase):
 
     def test_reverse_mixed_types(self):
         self.assertEqual(
-            (1, "cat", 4.0, "xyz"),
-            list_ops.reverse(("xyz", 4.0, "cat", 1))
-        )
+            [1, "cat", 4.0, "xyz"],
+            list_ops.reverse(["xyz", 4.0, "cat", 1]))
 
     def test_reverse_empty(self):
-        self.assertEqual([], list_ops.reverse(()))
+        self.assertEqual([], list_ops.reverse([]))
 
     # tests for append
     def test_append_tuple(self):
         self.assertEqual(
             ["10", "python", "hello"],
-            list_ops.append(["10", "python"], "hello")
-        )
+            list_ops.append(["10", "python"], "hello"))
 
     def test_append_range(self):
         self.assertEqual([100, range(1000)], list_ops.append([100], range(1000)))
@@ -116,20 +106,15 @@ class ListOpsTest(unittest.TestCase):
     def test_concat_two(self):
         self.assertEqual(
             [1, 3, 5, 8, 9, 4, 5, 6],
-            list_ops.concat([1, 3, 5, 8], [9, 4, 5, 6])
-        )
+            list_ops.concat([1, 3, 5, 8], [9, 4, 5, 6]))
 
     def test_concat_nothing(self):
         self.assertEqual(
             ["orange", "apple", "banana"],
-            list_ops.concat(['orange', 'apple', 'banana'], None)
-        )
+            list_ops.concat(['orange', 'apple', 'banana'], None))
 
     def test_concat_empty(self):
-        self.assertEqual(
-            [],
-            list_ops.concat([], [])
-        )
+        self.assertEqual([], list_ops.concat([], []))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
* i'd expect a reversed empty tuple to be an empty tuple and not an empty list