### PR TITLE
leap: Change tests `assertIs(..., True)` for `assertTrue(...)`

### DIFF
--- a/exercises/leap/leap_test.py
+++ b/exercises/leap/leap_test.py
@@ -5,19 +5,19 @@ from leap import is_leap_year
 
 class YearTest(unittest.TestCase):
     def test_leap_year(self):
-        self.assertIs(is_leap_year(1996), True)
+        self.assertTrue(is_leap_year(1996))
 
     def test_non_leap_year(self):
-        self.assertIs(is_leap_year(1997), False)
+        self.assertFalse(is_leap_year(1997))
 
     def test_non_leap_even_year(self):
-        self.assertIs(is_leap_year(1998), False)
+        self.assertFalse(is_leap_year(1998))
 
     def test_century(self):
-        self.assertIs(is_leap_year(1900), False)
+        self.assertFalse(is_leap_year(1900))
 
     def test_exceptional_century(self):
-        self.assertIs(is_leap_year(2400), True)
+        self.assertTrue(is_leap_year(2400))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Predicate functions shouldn't convert its implementation based on
logic expressions (combinations of `not`, `and` and `or`).

I.e. The following should be correct:

    def is_NOT_divisible_by_4(n):
        return n % 4

    assert is_NOT_divisible_by_4(10)

But as the TestCases for this exercise are using `assertIs(..., True)
instead of `assertTrue(...)`, implementations cointing on the numbers
behaviour on boolean contexts will Fail.

What this mean, is that for the given definition of
`is_NOT_divisible_by_4`, the folloging assertion will Fail:

    assert is_NOT_divisible_by_4(10) == True

I think it is meaningless to check for `True` as it is naive to write:

    if predicate(x) == True:
        do_something(x)

Instead of:

    if predicate(x):
        do_something(x)