### PR TITLE
Fix python version used to run tests

### DIFF
--- a/test/check-exercises.py
+++ b/test/check-exercises.py
@@ -12,6 +12,10 @@ import tempfile
 import json
 
 
+def python_executable_name():
+    return 'python{}.{}'.format(sys.version_info.major, sys.version_info.minor)
+
+
 def check_assignment(name, test_file):
     # Returns the exit code of the tests
     workdir = tempfile.mkdtemp(name)
@@ -21,7 +25,7 @@ def check_assignment(name, test_file):
         shutil.copyfile(test_file, test_file_out)
         shutil.copyfile(os.path.join(os.path.dirname(test_file), 'example.py'),
                         os.path.join(workdir, '{}.py'.format(example_name)))
-        return subprocess.call(['python', test_file_out])
+        return subprocess.call([python_executable_name(), test_file_out])
     finally:
         shutil.rmtree(workdir)
 

--- a/test/check-exercises.py
+++ b/test/check-exercises.py
@@ -95,6 +95,8 @@ def main():
                 failures.append('{} (TestFailed)'.format(exercise))
         print('')
 
+    print('TestEnvironment:', python_executable_name().capitalize(), end='\n\n')
+
     if failures:
         print('FAILURES: ', ', '.join(failures))
         raise SystemExit(1)


### PR DESCRIPTION
Even if the test runner itself is executed with a specific python version the subprocess used to execute the respective test script always uses the generic 'python' found in the PATH. On most systems that have python2 & 3 installed 'python' is a symlink to 'python2.X'. So this would mean that even if you would run 'python3 ./test/...py' the tests would still be run with python2.