### PR TITLE
largest-series-product: Update test cases

### DIFF
--- a/exercises/largest-series-product/largest_series_product_test.py
+++ b/exercises/largest-series-product/largest_series_product_test.py
@@ -11,33 +11,62 @@ import unittest
 from largest_series_product import largest_product
 
 
+# test cases adapted from `x-common//canonical-data.json` @ version: 1.0.0
+
 class SeriesTest(unittest.TestCase):
-    def test_largest_product_of_2(self):
-        self.assertEqual(largest_product("0123456789", 2), 72)
-
-    def test_largest_product_of_2_unordered(self):
-        self.assertEqual(largest_product("576802143", 2), 48)
-
-    def test__largest_product_span_equals_length(self):
+    def test_finds_the_largest_product_if_span_equals_length(self):
         self.assertEqual(largest_product("29", 2), 18)
 
-    def test_largest_product_of_3(self):
+    def test_can_find_the_largest_product_of_2_with_numbers_in_order(self):
+        self.assertEqual(largest_product("0123456789", 2), 72)
+
+    def test_can_find_the_largest_product_of_2(self):
+        self.assertEqual(largest_product("576802143", 2), 48)
+
+    def test_can_find_the_largest_product_of_3_with_numbers_in_order(self):
         self.assertEqual(largest_product("0123456789", 3), 504)
 
-    def test_largest_product_of_3_unordered(self):
+    def test_can_find_the_largest_product_of_3(self):
         self.assertEqual(largest_product("1027839564", 3), 270)
 
-    def test_largest_product_of_5(self):
+    def test_can_find_the_largest_product_of_5_with_numbers_in_order(self):
         self.assertEqual(largest_product("0123456789", 5), 15120)
 
-    def test_big_number(self):
-        series = "73167176531330624919225119674426574742355349194934"
-        self.assertEqual(largest_product(series, 6), 23520)
+    def test_can_get_the_largest_product_of_a_big_number(self):
+        self.assertEqual(
+            largest_product(
+                "73167176531330624919225119674426574742355349194934", 6),
+            23520)
 
-    def test_another_big_number(self):
-        series = "52677741234314237566414902593461595376319419139427"
-        self.assertEqual(largest_product(series, 6), 28350)
+    def test_reports_zero_if_the_only_digits_are_zero(self):
+        self.assertEqual(largest_product("0000", 2), 0)
 
+    def test_reports_zero_if_all_spans_include_zero(self):
+        self.assertEqual(largest_product("99099", 3), 0)
+
+    def test_rejects_span_longer_than_string_length(self):
+        with self.assertRaises(ValueError):
+            largest_product("123", 4)
+
+    def test_reports_1_for_empty_string_and_empty_product_0_span(self):
+        self.assertEqual(largest_product("", 0), 1)
+
+    def test_reports_1_for_nonempty_string_and_empty_product_0_span(self):
+        self.assertEqual(largest_product("123", 0), 1)
+
+    def test_rejects_empty_string_and_nonzero_span(self):
+        with self.assertRaises(ValueError):
+            largest_product("", 1)
+
+    def test_rejects_invalid_character_in_digits(self):
+        with self.assertRaises(ValueError):
+            largest_product("1234a5", 2)
+
+    def test_rejects_negative_span(self):
+        with self.assertRaises(ValueError):
+            largest_product("12345", -1)
+
+    @unittest.skip("extra-credit")
     def test_project_euler_big_number(self):
         series = (
             "73167176531330624919225119674426574742355349194934969835203127745"
@@ -57,34 +86,6 @@ class SeriesTest(unittest.TestCase):
             "71094050775410022569831552000559357297257163626956188267042825248"
             "3600823257530420752963450")
         self.assertEqual(largest_product(series, 13), 23514624000)
-
-    def test_all_digits_zero(self):
-        self.assertEqual(largest_product("0000", 2), 0)
-
-    def test_all_spans_contain_zero(self):
-        self.assertEqual(largest_product("99099", 3), 0)
-
-    def test_identity_with_empty_string(self):
-        self.assertEqual(largest_product("", 0), 1)
-
-    def test_identity_with_nonempty_string(self):
-        self.assertEqual(largest_product("123", 0), 1)
-
-    def test_span_long_than_number(self):
-        with self.assertRaises(ValueError):
-            largest_product("123", 4)
-
-    def test_nonzero_span_and_empty_string(self):
-        with self.assertRaises(ValueError):
-            largest_product("", 1)
-
-    def test_digits_with_invalid_character(self):
-        with self.assertRaises(ValueError):
-            largest_product("1234a5", 2)
-
-    def test_negative_span(self):
-        with self.assertRaises(ValueError):
-            largest_product("12345", -1)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Updates the test suite according to the canonical test data and stores the test data version.

The `big number with span of 13` test case was removed from the canonical test data (https://github.com/exercism/x-common/pull/471). I think it's a good *extra credit* case, so I changed it into a skipped test.