### PR TITLE
book-store: Add new exercise

### DIFF
--- a/config.json
+++ b/config.json
@@ -417,6 +417,12 @@
       ]
     },
     {
+      "slug": "book-store",
+      "difficulty": 1,
+      "topics": [
+      ]
+    },
+    {
       "slug": "linked-list",
       "difficulty": 1,
       "topics": [

--- a/exercises/book-store/book_store.py
+++ b/exercises/book-store/book_store.py
@@ -1,0 +1,2 @@
+def calculate_total():
+    pass

--- a/exercises/book-store/book_store_test.py
+++ b/exercises/book-store/book_store_test.py
@@ -1,0 +1,72 @@
+import unittest
+
+from book_store import calculate_total
+
+
+# test cases adapted from `x-common//canonical-data.json` @ version: 1.0.0
+
+class BookStoreTests(unittest.TestCase):
+    def test_only_a_single_book(self):
+        self.assertAlmostEqual(calculate_total([1]), 8.00,
+                               places=2)
+
+    def test_two_of_the_same_book(self):
+        self.assertAlmostEqual(calculate_total([2, 2]), 16.00,
+                               places=2)
+
+    def test_empty_basket(self):
+        self.assertAlmostEqual(calculate_total([]), 0.00,
+                               places=2)
+
+    def test_two_different_books(self):
+        self.assertAlmostEqual(calculate_total([1, 2]), 15.20,
+                               places=2)
+
+    def test_three_different_books(self):
+        self.assertAlmostEqual(calculate_total([1, 2, 3]), 21.60,
+                               places=2)
+
+    def test_four_different_books(self):
+        self.assertAlmostEqual(calculate_total([1, 2, 3, 4]), 25.60,
+                               places=2)
+
+    def test_five_different_books(self):
+        self.assertAlmostEqual(
+            calculate_total([1, 2, 3, 4, 5]), 30.00,
+            places=2)
+
+    def test_two_groups_of_4_is_cheaper_than_group_of_5_plus_group_of_3(self):
+        self.assertAlmostEqual(
+            calculate_total([1, 1, 2, 2, 3, 3, 4, 5]), 51.20,
+            places=2)
+
+    def test_group_of_4_plus_group_of_2_is_cheaper_than_2_groups_of_3(self):
+        self.assertAlmostEqual(
+            calculate_total([1, 1, 2, 2, 3, 4]), 40.80,
+            places=2)
+
+    def test_two_each_of_first_4_books_and_1_copy_each_of_rest(self):
+        self.assertAlmostEqual(
+            calculate_total([1, 1, 2, 2, 3, 3, 4, 4, 5]), 55.60,
+            places=2)
+
+    def test_two_copies_of_each_book(self):
+        self.assertAlmostEqual(
+            calculate_total([1, 1, 2, 2, 3, 3, 4, 4, 5, 5]), 60.00,
+            places=2)
+
+    def test_three_copies_of_first_book_and_2_each_of_remaining(self):
+        self.assertAlmostEqual(
+            calculate_total([1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 1]),
+            68.00,
+            places=2)
+
+    def test_three_each_of_first_2_books_and_2_each_of_remaining_books(self):
+        self.assertAlmostEqual(
+            calculate_total([1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 1, 2]),
+            75.20,
+            places=2)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/exercises/book-store/example.py
+++ b/exercises/book-store/example.py
@@ -1,0 +1,29 @@
+BOOK_PRICE = 8
+
+
+def _group_price(size):
+    discounts = [0, .05, .1, .2, .25]
+    if not (0 < size <= 5):
+        raise ValueError('size must be in 1..' + len(discounts))
+    return 8 * size * (1 - discounts[size - 1])
+
+
+def calculate_total(books, price_so_far=0.):
+    if not books:
+        return price_so_far
+
+    groups = list(set(books))
+    min_price = float('inf')
+
+    for i in range(len(groups)):
+
+        remaining_books = books[:]
+
+        for v in groups[:i + 1]:
+            remaining_books.remove(v)
+
+        price = calculate_total(remaining_books,
+                                price_so_far + _group_price(i + 1))
+        min_price = min(min_price, price)
+
+    return min_price


### PR DESCRIPTION
Definitely not an elegant solution, but it should be enough to validate the test cases.

I'm especially not sure about the range check in `_group_price(size)` because neither the description nor the canonical test data suggest how to handle bigger groups than 5. Maybe instead of raising a `ValueError` we could just keep the last discount or we just assume that there won't be more than five ... I don't know.