### PR TITLE
grade-school: catch false positives due to test case being sorted already

### DIFF
--- a/exercises/grade-school/grade_school_test.py
+++ b/exercises/grade-school/grade_school_test.py
@@ -46,7 +46,7 @@ class SchoolTest(unittest.TestCase):
                     (6, ("Kareem", ))]
 
         for grade, students_in_grade in students[::-1]:
-            for student in students_in_grade:
+            for student in students_in_grade[::-1]:
                 self.school.add(student, grade)
 
         result = self.school.sort()

--- a/exercises/grade-school/grade_school_test.py
+++ b/exercises/grade-school/grade_school_test.py
@@ -45,7 +45,7 @@ class SchoolTest(unittest.TestCase):
         students = [(3, ("Kyle", )), (4, ("Christopher", "Jennifer", )),
                     (6, ("Kareem", ))]
 
-        for grade, students_in_grade in students:
+        for grade, students_in_grade in students[::-1]:
             for student in students_in_grade:
                 self.school.add(student, grade)
 


### PR DESCRIPTION
From Python 3.6 on, dictionaries retain the order in which items are
added. If the test case puts the items into the tested class in sorted
order, even a naive implementation (one that does no sorting) can pass
by giving back all items in the original order.